### PR TITLE
Leakage suppression

### DIFF
--- a/examples/tests/test.ipynb
+++ b/examples/tests/test.ipynb
@@ -1,0 +1,236 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using Revise\n",
+    "using NamedTrajectories\n",
+    "using QuantumCollocation\n",
+    "using LinearAlgebra\n",
+    "using SparseArrays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2-element Vector{Int64}:\n",
+       " 3\n",
+       " 3"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "levels = [3, 3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9×9 Matrix{Complex{Int64}}:\n",
+       " 1+82im  10+91im  19+100im  28+109im  …  55+136im  64+145im  73+154im\n",
+       " 2+83im  11+92im  20+101im  29+110im     56+137im  65+146im  74+155im\n",
+       " 3+84im  12+93im  21+102im  30+111im     57+138im  66+147im  75+156im\n",
+       " 4+85im  13+94im  22+103im  31+112im     58+139im  67+148im  76+157im\n",
+       " 5+86im  14+95im  23+104im  32+113im     59+140im  68+149im  77+158im\n",
+       " 6+87im  15+96im  24+105im  33+114im  …  60+141im  69+150im  78+159im\n",
+       " 7+88im  16+97im  25+106im  34+115im     61+142im  70+151im  79+160im\n",
+       " 8+89im  17+98im  26+107im  35+116im     62+143im  71+152im  80+161im\n",
+       " 9+90im  18+99im  27+108im  36+117im     63+144im  72+153im  81+162im"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "N = prod(levels)\n",
+    "U = reshape(1:N^2, N, N)\n",
+    "U += im * (U .+ N^2)\n",
+    "U"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5-element Vector{Int64}:\n",
+       " 3\n",
+       " 6\n",
+       " 7\n",
+       " 8\n",
+       " 9"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "subspace_inds = subspace_indices(levels)\n",
+    "leakage_inds = subspace_leakage_indices(levels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5×4 Matrix{Complex{Int64}}:\n",
+       " 3+84im  12+93im  30+111im  39+120im\n",
+       " 6+87im  15+96im  33+114im  42+123im\n",
+       " 7+88im  16+97im  34+115im  43+124im\n",
+       " 8+89im  17+98im  35+116im  44+125im\n",
+       " 9+90im  18+99im  36+117im  45+126im"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "U[leakage_inds, subspace_inds]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "162-element Vector{Float64}:\n",
+       "   1.0\n",
+       "   2.0\n",
+       "   3.0\n",
+       "   4.0\n",
+       "   5.0\n",
+       "   6.0\n",
+       "   7.0\n",
+       "   8.0\n",
+       "   9.0\n",
+       "  82.0\n",
+       "   ⋮\n",
+       " 154.0\n",
+       " 155.0\n",
+       " 156.0\n",
+       " 157.0\n",
+       " 158.0\n",
+       " 159.0\n",
+       " 160.0\n",
+       " 161.0\n",
+       " 162.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Ũ⃗ = operator_to_iso_vec(U)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9×9 Matrix{Complex{Int64}}:\n",
+       " 0+0im    0+0im   0+0im   0+0im     0+0im    0+0im  0+0im  0+0im  0+0im\n",
+       " 0+0im    0+0im   0+0im   0+0im     0+0im    0+0im  0+0im  0+0im  0+0im\n",
+       " 3+84im  12+93im  0+0im  30+111im  39+120im  0+0im  0+0im  0+0im  0+0im\n",
+       " 0+0im    0+0im   0+0im   0+0im     0+0im    0+0im  0+0im  0+0im  0+0im\n",
+       " 0+0im    0+0im   0+0im   0+0im     0+0im    0+0im  0+0im  0+0im  0+0im\n",
+       " 6+87im  15+96im  0+0im  33+114im  42+123im  0+0im  0+0im  0+0im  0+0im\n",
+       " 7+88im  16+97im  0+0im  34+115im  43+124im  0+0im  0+0im  0+0im  0+0im\n",
+       " 8+89im  17+98im  0+0im  35+116im  44+125im  0+0im  0+0im  0+0im  0+0im\n",
+       " 9+90im  18+99im  0+0im  36+117im  45+126im  0+0im  0+0im  0+0im  0+0im"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "iso_leakage_inds = unitary_isomorphism_leakage_indices(levels)\n",
+    "for i = axes(Ũ⃗, 1) \n",
+    "    if i ∉ iso_leakage_inds\n",
+    "        Ũ⃗[i] = 0\n",
+    "    end\n",
+    "end\n",
+    "Matrix{Complex{Int}}(iso_vec_to_operator(Ũ⃗))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element Vector{Any}:\n",
+       "  3\n",
+       "  6\n",
+       "  9\n",
+       " 12"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "iso_leakage_inds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.9.2",
+   "language": "julia",
+   "name": "julia-1.9"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.9.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/objectives.jl
+++ b/src/objectives.jl
@@ -636,6 +636,7 @@ function MinimumTimeObjective(;
         :eval_hessian => eval_hessian
     )
 
+    # TODO: amend this for case of no TimeStepsAllEqualConstraint
 	L(Z⃗::AbstractVector, Z::NamedTrajectory) = D * Z⃗[Δt_indices][end]
 
 	∇L = (Z⃗::AbstractVector, Z::NamedTrajectory) -> begin


### PR DESCRIPTION
added `leakage_suppression` flag to `UnitarySmoothPulseProblem` template.  requires passing `system_levels` value for creating leakage space indices.