### PR TITLE
Robust control objectives

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -233,7 +233,7 @@ is the NamedTrajectory symbol representing the unitary.
 function FinalUnitaryFidelityConstraint(
     statesymb::Symbol,
     val::Float64,
-    traj::NamedTrajectory,
+    traj::NamedTrajectory;
     subspace::Union{AbstractVector{<:Integer}, Nothing}=nothing
 )
     @assert statesymb ∈ traj.names

--- a/src/objectives.jl
+++ b/src/objectives.jl
@@ -662,4 +662,112 @@ function MinimumTimeObjective(traj::NamedTrajectory; D=1.0)
     return MinimumTimeObjective(; D=D, Δt_indices=Δt_indices)
 end
 
+@doc raw"""
+QuantumRobustnessObjective(
+        Hₑ::AbstractMatrix{<:Number},
+        Z::NamedTrajectory;
+        eval_hessian::Bool=false,
+        subspace::Union{AbstractVector{<:Integer}, Nothing}=nothing
+    )
+
+Create a control objective which penalizes the sensitivity of the fidelity
+to the provided operator defined in the subspace of the control dynamics, 
+thereby realizing robust control.
+
+The control dynamics are
+```math
+U_C(a)= \prod_t \exp{-i H_C(a_t)}
+```
+
+In the control frame, the Hₑ operator is (proportional to)
+```math
+R_{Robust}(a) = \frac{1}{T \norm{H_e}_2} \sum_t U_C(a_t)^\dag H_e U_C(a_t) \Delta t
+```
+where we have adjusted to a unitless expression of the operator.
+
+The robustness objective is 
+```math
+R_{Robust}(a) = \frac{1}{N} \norm{R}^2_F
+```
+where N is the dimension of the Hilbert space.
+"""
+function QuantumRobustnessObjective(
+    Hₑ::AbstractMatrix{<:Number},
+    Z::NamedTrajectory;
+    eval_hessian::Bool=false,
+    subspace::Union{AbstractVector{<:Integer}, Nothing}=nothing
+)
+    # Indices of all non-zero subspace components for iso_vec_operators 
+    function iso_vec_subspace(subspace::AbstractVector{<:Integer}, Z::NamedTrajectory)
+        d = isqrt(Z.dims[:Ũ⃗] ÷ 2)
+        A = zeros(Complex, d, d)
+        A[subspace, subspace] .= 1 + im
+        # Return any index where there is a 1.
+        return [j for (s, j) ∈ zip(operator_to_iso_vec(A), Z.components[:Ũ⃗]) if convert(Bool, s)]
+    end
+    ivs = iso_vec_subspace(isnothing(subspace) ? collect(1:size(Hₑ, 1)) : subspace, Z)
+    T = sum(NT.timesteps(Z))
+
+    @views function timesteps(Z⃗::AbstractVector{<:Real}, Z::NamedTrajectory)
+        return map(1:Z.T) do t
+            if Z.timestep isa Symbol
+                Z⃗[slice(t, Z.components[Z.timestep], Z.dim)][1]
+            else
+                Z.timestep
+            end
+        end
+    end
+
+    # Control frame
+    @views function toggle(Z⃗::AbstractVector{<:Real}, Z::NamedTrajectory)
+        Δts = timesteps(Z⃗, Z)
+        R = sum(
+            map(1:Z.T) do t
+                Uₜ = iso_vec_to_operator(Z⃗[slice(t, ivs, Z.dim)])
+                Uₜ'Hₑ*Uₜ .* Δts[t]
+            end
+        ) / norm(Hₑ) / T
+        return R
+    end
+
+    function L(Z⃗::AbstractVector{<:Real}, Z::NamedTrajectory)
+        R = toggle(Z⃗, Z)
+        return real(tr(R'R)) / size(R, 1)
+    end
+
+    @views function ∇L(Z⃗::AbstractVector{<:Real}, Z::NamedTrajectory)
+        ∇ = zeros(Z.dim * Z.T)
+        R = toggle(Z⃗, Z)
+        Δts = timesteps(Z⃗, Z)
+        Threads.@threads for t ∈ 1:Z.T
+            # State gradients
+            Uₜ_slice = slice(t, ivs, Z.dim)
+            Uₜ = iso_vec_to_operator(Z⃗[Uₜ_slice])
+            ∇[Uₜ_slice] .= 2 .* operator_to_iso_vec(
+                Hₑ * Uₜ * R .* Δts[t]
+            ) / norm(Hₑ) / T
+            # Time gradients
+            if Z.timestep isa Symbol 
+                t_slice = slice(t, Z.components[Z.timestep], Z.dim)
+                ∂R = Uₜ'Hₑ*Uₜ
+                ∇[t_slice] .= tr(∂R*R + R*∂R) / norm(Hₑ) / T
+            end
+        end
+        return ∇ / size(R, 1)
+    end
+
+    # Hessian is approximately dense, R contains all unitaries
+    ∂²L = nothing
+    ∂²L_structure = nothing
+
+    params = Dict(
+        :type => :QuantumRobustnessObjective,
+        :error => Hₑ,
+        :eval_hessian => eval_hessian
+    )
+
+    return Objective(L, ∇L, ∂²L, ∂²L_structure, Dict[params])
+end
+
+
 end

--- a/src/objectives.jl
+++ b/src/objectives.jl
@@ -8,6 +8,7 @@ export QuantumUnitaryObjective
 export UnitaryInfidelityObjective
 
 export MinimumTimeObjective
+export InfidelityRobustnessObjective
 
 export QuadraticRegularizer
 export QuadraticSmoothnessRegularizer
@@ -663,14 +664,14 @@ function MinimumTimeObjective(traj::NamedTrajectory; D=1.0)
 end
 
 @doc raw"""
-QuantumRobustnessObjective(
+InfidelityRobustnessObjective(
         Hₑ::AbstractMatrix{<:Number},
         Z::NamedTrajectory;
         eval_hessian::Bool=false,
         subspace::Union{AbstractVector{<:Integer}, Nothing}=nothing
     )
 
-Create a control objective which penalizes the sensitivity of the fidelity
+Create a control objective which penalizes the sensitivity of the infidelity
 to the provided operator defined in the subspace of the control dynamics, 
 thereby realizing robust control.
 
@@ -691,7 +692,7 @@ R_{Robust}(a) = \frac{1}{N} \norm{R}^2_F
 ```
 where N is the dimension of the Hilbert space.
 """
-function QuantumRobustnessObjective(
+function InfidelityRobustnessObjective(
     Hₑ::AbstractMatrix{<:Number},
     Z::NamedTrajectory;
     eval_hessian::Bool=false,
@@ -756,9 +757,15 @@ function QuantumRobustnessObjective(
         return ∇ / size(R, 1)
     end
 
-    # Hessian is approximately dense, R contains all unitaries
-    ∂²L = nothing
-    ∂²L_structure = nothing
+    # Hessian is dense (Control frame R contains sum over all unitaries).
+    if eval_hessian
+        # TODO
+		∂²L = (Z⃗, Z) -> []
+		∂²L_structure = Z -> []
+	else
+		∂²L = nothing
+		∂²L_structure = nothing
+	end
 
     params = Dict(
         :type => :QuantumRobustnessObjective,

--- a/src/problem_templates.jl
+++ b/src/problem_templates.jl
@@ -412,6 +412,7 @@ function UnitaryRobustnessProblem(
     constraints::Vector{<:AbstractConstraint};
     unitary_symbol::Symbol=:Ũ⃗,
     final_fidelity::Float64=unitary_fidelity(trajectory[end][unitary_symbol], trajectory.goal[unitary_symbol]),
+    subspace::Union{AbstractVector{<:Integer}, Nothing}=nothing,
     eval_hessian::Bool=false,
     verbose::Bool=false,
     ipopt_options::Options=Options(),
@@ -433,7 +434,7 @@ function UnitaryRobustnessProblem(
     fidelity_constraint = FinalUnitaryFidelityConstraint(
         unitary_symbol,
         final_fidelity,
-        trajectory,
+        trajectory;
         subspace=subspace
     )
 

--- a/src/problem_templates.jl
+++ b/src/problem_templates.jl
@@ -453,7 +453,7 @@ function UnitaryRobustnessProblem(
 end
 
 function UnitaryRobustnessProblem(
-    Hₑ::AstractMatrix{<:Number},
+    Hₑ::AbstractMatrix{<:Number},
     prob::QuantumControlProblem;
     kwargs...
 )

--- a/src/problem_templates.jl
+++ b/src/problem_templates.jl
@@ -2,6 +2,7 @@ module ProblemTemplates
 
 export UnitarySmoothPulseProblem
 export UnitaryMinimumTimeProblem
+export UnitaryRobustnessProblem
 
 export QuantumStateSmoothPulseProblem
 export QuantumStateMinimumTimeProblem
@@ -359,7 +360,7 @@ function UnitaryMinimumTimeProblem(
     kwargs...
 )
     params = deepcopy(prob.params)
-    traj = copy(prob.trajectory)
+    trajectory = copy(prob.trajectory)
     system = prob.system
     objective = Objective(params[:objective_terms])
     integrators = prob.integrators
@@ -368,7 +369,7 @@ function UnitaryMinimumTimeProblem(
         NonlinearConstraint.(params[:nonlinear_constraints])...
     ]
     return UnitaryMinimumTimeProblem(
-        traj,
+        trajectory,
         system,
         objective,
         integrators,
@@ -377,7 +378,6 @@ function UnitaryMinimumTimeProblem(
         kwargs...
     )
 end
-
 
 function UnitaryMinimumTimeProblem(
     data_path::String;
@@ -451,6 +451,34 @@ function UnitaryRobustnessProblem(
         kwargs...
     )
 end
+
+function UnitaryRobustnessProblem(
+    Hₑ::AstractMatrix{<:Number},
+    prob::QuantumControlProblem;
+    kwargs...
+)
+    params = deepcopy(prob.params)
+    trajectory = copy(prob.trajectory)
+    system = prob.system
+    objective = Objective(params[:objective_terms])
+    integrators = prob.integrators
+    constraints = [
+        params[:linear_constraints]...,
+        NonlinearConstraint.(params[:nonlinear_constraints])...
+    ]
+
+    return UnitaryRobustnessProblem(
+        Hₑ,
+        trajectory,
+        system,
+        objective,
+        integrators,
+        constraints;
+        build_trajectory_constraints=false,
+        kwargs...
+    )
+end
+
 
 # ------------------------------------------
 # Quantum State Problem Templates

--- a/src/quantum_utils.jl
+++ b/src/quantum_utils.jl
@@ -1,7 +1,6 @@
 module QuantumUtils
 
 export GATES
-export gate
 export ⊗
 export apply
 export qubit_system_state
@@ -35,30 +34,16 @@ using LinearAlgebra
 
 
 """
-    ⊗(A::AbstractVecOrMat, B::AbstractVecOrMat)
-
-Kronecker product of two vectors or matrices.
+    kronecker product utility
 """
+
 ⊗(A::AbstractVecOrMat, B::AbstractVecOrMat) = kron(A, B)
 
 
-@doc raw"""
-    GATES::Dict{Symbol, Matrix{ComplexF64}}
-
-Dictionary of common quantum gates.
-
-# Elements
-- `:I` - identity, $I$
-- `:X` - Pauli X, $\sigma_x$
-- `:Y` - Pauli Y, $\sigma_y$
-- `:Z` - Pauli Z, $\sigma_z$
-- `:H` - Hadamard, $H$
-- `:CX` - controlled-X, $C_X$
-- `:XI` - $-i X \otimes I$
-- `:sqrtiSWAP` - $\sqrt{i \text{SWAP}}$
-
-
 """
+    quantum gates
+"""
+
 const GATES = Dict(
     :I => [1 0;
            0 1],
@@ -91,18 +76,8 @@ const GATES = Dict(
                    0 0 0 1]
 )
 
-"""
-    gate(U::Symbol)
-
-Get a gate from the `GATES` dictionary.
-"""
 gate(U::Symbol) = GATES[U]
 
-"""
-    apply(gate::Symbol, ψ::Vector{<:Number})
-
-Apply a gate from the GATES dictionary to a quantum state.
-"""
 function apply(gate::Symbol, ψ::Vector{<:Number})
     @assert norm(ψ) ≈ 1.0
     @assert gate in keys(GATES) "gate not found"
@@ -111,11 +86,6 @@ function apply(gate::Symbol, ψ::Vector{<:Number})
     return ComplexF64.(normalize(Û * ψ))
 end
 
-@doc raw"""
-    qubit_system_state(ket::String)
-
-Get a quantum state from a string of qubit states, e.g. `"01"` -> $\ket{01}$.
-"""
 function qubit_system_state(ket::String)
     cs = [c for c ∈ ket]
     @assert all(c ∈ "01" for c ∈ cs)
@@ -125,43 +95,17 @@ function qubit_system_state(ket::String)
     return ψ
 end
 
-
-@doc raw"""
-    lift(
-        U::AbstractMatrix{<:Number},
-        i::Int,
-        n::Int;
-        levels::Int=size(U, 1)
-    )
-
-Lift a matrix to a larger Hilbert space by placing it on the `i`-th qubit of a `n`-qubit system. I.e.,
-```math
-U \mapsto I_1 \otimes \cdots \otimes I_{i-1} \otimes U \otimes I_{i+1} \otimes \cdots \otimes I_n
-```
-"""
 function lift(
     U::AbstractMatrix{<:Number},
-    i::Int,
-    n::Int;
+    qubit_index::Int,
+    n_qubits::Int;
     levels::Int=size(U, 1)
 )::Matrix{ComplexF64}
-    Is = Matrix{Complex}[I(levels) for _ = 1:n]
-    Is[i] = U
+    Is = Matrix{Complex}[I(levels) for _ = 1:n_qubits]
+    Is[qubit_index] = U
     return foldr(⊗, Is)
 end
 
-@doc raw"""
-    lift(
-        op::AbstractMatrix{<:Number},
-        i::Int,
-        levels::Vector{Int}
-    )
-
-Lift a matrix to a larger Hilbert space by placing it on the `i`-th qubit of a `n`-qubit system. I.e.,
-```math
-U \mapsto I_1 \otimes \cdots \otimes I_{i-1} \otimes U \otimes I_{i+1} \otimes \cdots \otimes I_n
-```
-"""
 function lift(
     op::AbstractMatrix{<:Number},
     i::Int,

--- a/test/problem_templates_test.jl
+++ b/test/problem_templates_test.jl
@@ -3,6 +3,7 @@
 #
 # 1. test UnitarySmoothPulseProblem
 # 2. test UnitaryMinimumTimeProblem
+# 3. test UnitaryRobustnessProblem
 # ------------------------------------------------
 
 
@@ -37,6 +38,93 @@
     @test unitary_fidelity(mintime_prob) > final_fidelity
 
     @test times(mintime_prob.trajectory)[end] < times(prob.trajectory)[end]
+
+end
+
+
+
+@testset "Robust and Subspace Templates" begin
+    # --------------------------------------------
+    # Initialize with UnitarySmoothPulseProblem
+    # --------------------------------------------
+    H_drift = zeros(2, 2)
+    H_drives = [GATES[:X], GATES[:Y]]
+    U_goal = GATES[:X]
+    T = 50
+    Δt = .2
+
+    probs = Dict()
+    
+    probs["qubit"] = UnitarySmoothPulseProblem(
+        H_drift, H_drives, U_goal, T, Δt;
+        verbose=false
+    )
+    
+    solve!(probs["qubit"]; max_iter=100)
+    
+    @test unitary_fidelity(probs["qubit"]) > 0.99
+    
+    # --------------------------------------------
+    # 1. test UnitarySmoothPulseProblem with subspace
+    # --------------------------------------------
+    H_error = GATES[:Z]
+    H_drift = zeros(3, 3)
+    H_drives = [create(3) + annihilate(3), im * (create(3) - annihilate(3))]
+    U_goal = [0 1 0; 1 0 0; 0 0 0]
+    T = probs["qubit"].trajectory.T
+    Δt = probs["qubit"].trajectory[:Δt][1]
+    a_guess = probs["qubit"].trajectory[:a]
+    
+    subspace = subspace_indices([3])
+    probs["transmon"] = UnitarySmoothPulseProblem(
+        H_drift, H_drives, U_goal, T, Δt;
+        a_guess=a_guess, subspace=subspace, geodesic=false, verbose=false
+    )
+    solve!(probs["transmon"]; max_iter=100)
+    
+    # Subspace gate success
+    @test unitary_fidelity(probs["transmon"]; subspace=subspace) > 0.99
+
+
+    # --------------------------------------------
+    # 3. test UnitaryRobustnessProblem from previous problem
+    # --------------------------------------------
+    probs["robust"] = UnitaryRobustnessProblem(
+        H_error, probs["transmon"];
+        final_fidelity=0.99, subspace=subspace, verbose=false    
+    )
+    solve!(probs["robust"]; max_iter=100)
+    
+    EvalLoss(problem, Loss) = Loss(vec(problem.trajectory.data), problem.trajectory)
+    Loss = InfidelityRobustnessObjective(H_error, probs["transmon"].trajectory).L
+
+    # Robustness improvement over default
+    @test EvalLoss(probs["robust"], Loss) < EvalLoss(probs["transmon"], Loss)
+    
+    # Fidelity constraint approximately satisfied
+    @test isapprox(unitary_fidelity(probs["robust"]; subspace=subspace), 0.99, atol=0.025)
+    
+    # --------------------------------------------
+    # 4. test UnitaryRobustnessProblem from default struct
+    # --------------------------------------------
+    params = deepcopy(probs["transmon"].params)
+    trajectory = copy(probs["transmon"].trajectory)
+    system = probs["transmon"].system
+    objective = QuadraticRegularizer(:dda, trajectory, 1e-4)
+    integrators = probs["transmon"].integrators
+    constraints = AbstractConstraint[]
+    
+    probs["unconstrained"] = UnitaryRobustnessProblem(
+        H_error, trajectory, system, objective, integrators, constraints;
+        final_fidelity=0.99, subspace=subspace, verbose=false
+    )
+    solve!(probs["unconstrained"]; max_iter=100)
+    
+    # Additonal robustness improvement after relaxed objective
+    @test EvalLoss(probs["unconstrained"], Loss) < EvalLoss(probs["transmon"], Loss)
+    
+    # Fidelity constraint approximately satisfied
+    @test isapprox(unitary_fidelity(probs["unconstrained"]; subspace=subspace), 0.99, atol=0.025)
 
 
 end

--- a/test/problem_templates_test.jl
+++ b/test/problem_templates_test.jl
@@ -54,6 +54,7 @@ end
     subspace = subspace_indices([3])
     T = 50
     Δt = .2
+    probs = Dict()
 
     # --------------------------------------------
     #   1. test UnitarySmoothPulseProblem with subspace
@@ -104,7 +105,7 @@ end
     solve!(probs["unconstrained"]; max_iter=100)
     
     # Additonal robustness improvement after relaxed objective
-    @test eval_loss(probs["unconstrained"], Loss) < eval_loss(probs["transmon"], Loss)
+    @test eval_loss(probs["unconstrained"], loss) < eval_loss(probs["transmon"], loss)
     
     # Fidelity constraint approximately satisfied
     @test isapprox(unitary_fidelity(probs["unconstrained"]; subspace=subspace), 0.99, atol=0.025)

--- a/test/problem_templates_test.jl
+++ b/test/problem_templates_test.jl
@@ -95,11 +95,11 @@ end
     )
     solve!(probs["robust"]; max_iter=100)
     
-    EvalLoss(problem, Loss) = Loss(vec(problem.trajectory.data), problem.trajectory)
-    Loss = InfidelityRobustnessObjective(H_error, probs["transmon"].trajectory).L
+    eval_loss(problem, Loss) = Loss(vec(problem.trajectory.data), problem.trajectory)
+    loss = InfidelityRobustnessObjective(H_error, probs["transmon"].trajectory).L
 
     # Robustness improvement over default
-    @test EvalLoss(probs["robust"], Loss) < EvalLoss(probs["transmon"], Loss)
+    @test eval_loss(probs["robust"], loss) < eval_loss(probs["transmon"], loss)
     
     # Fidelity constraint approximately satisfied
     @test isapprox(unitary_fidelity(probs["robust"]; subspace=subspace), 0.99, atol=0.025)
@@ -121,7 +121,7 @@ end
     solve!(probs["unconstrained"]; max_iter=100)
     
     # Additonal robustness improvement after relaxed objective
-    @test EvalLoss(probs["unconstrained"], Loss) < EvalLoss(probs["transmon"], Loss)
+    @test eval_loss(probs["unconstrained"], Loss) < eval_loss(probs["transmon"], Loss)
     
     # Fidelity constraint approximately satisfied
     @test isapprox(unitary_fidelity(probs["unconstrained"]; subspace=subspace), 0.99, atol=0.025)


### PR DESCRIPTION
Adds `InfidelityRobustnessObjective` to penalize sensitivity of infidelity to static operators.

`FinalFidelityConstraint` now includes a subspace argument. New problem templates and tests have also been added, see `UnitaryRobustnessProblem`. These are following the format established by `UnitaryMinimumTimeProblem`.

Closes #49.