### PR TITLE
Add timesteps to quadratic regularizers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /examples/**/trajectories/
 pardiso.lic
 /.CondaPkg/
+*.code-workspace


### PR DESCRIPTION
Modifies loss, gradient, and hessian of `QuadraticRegularizer` to use timesteps. That is, the loss is now `0.5 * (Δt .* vₜ)' * (R .* ( Δt .* vₜ))` instead of `0.5 * vₜ' * (R .*  vₜ)`. This enforces an energy (integral) constraint, preventing the optimizer from stretching variable timesteps in order to minimize `QuadraticRegularizer` losses.

Closes #47