### PR TITLE
Override control prob defaults in templates

### DIFF
--- a/src/objectives.jl
+++ b/src/objectives.jl
@@ -1,7 +1,7 @@
 module Objectives
 
 export Objective
-
+export DefaultObjective
 export QuantumObjective
 export QuantumStateObjective
 export QuantumUnitaryObjective
@@ -85,6 +85,36 @@ function sparse_to_moi(A::SparseMatrixCSC)
     vals = [A[i,j] for (i,j) ∈ inds]
     return (inds, vals)
 end
+
+"""
+    DefaultObjective
+
+    
+"""
+function DefaultObjective()
+    params = Dict()
+
+	@views function L(Z⃗::AbstractVector{<:Real}, Z::NamedTrajectory)
+        return 0.0
+    end
+
+    @views function ∇L(Z⃗::AbstractVector{<:Real}, Z::NamedTrajectory)
+        ∇ = zeros(Z.dim * Z.T)
+        return ∇
+    end
+
+    function ∂²L_structure(Z::NamedTrajectory)
+        structure = []
+        return structure
+    end
+
+    @views function ∂²L(Z⃗::AbstractVector{<:Real}, Z::NamedTrajectory; return_moi_vals=true)
+        return return_moi_vals ? [] : spzeros(Z.dim * Z.T, Z.dim * Z.T)
+    end
+
+	return Objective(L, ∇L, ∂²L, ∂²L_structure, Dict[params])
+end
+
 """
     QuantumObjective
 

--- a/src/problem_templates.jl
+++ b/src/problem_templates.jl
@@ -357,24 +357,36 @@ end
 
 function UnitaryMinimumTimeProblem(
     prob::QuantumControlProblem;
+    constraints::Union{Vector{<:AbstractConstraint}, Nothing}=nothing,
+    objective::Union{Objective, Nothing}=nothing,
     kwargs...
 )
     params = deepcopy(prob.params)
     trajectory = copy(prob.trajectory)
     system = prob.system
-    objective = Objective(params[:objective_terms])
     integrators = prob.integrators
-    constraints = [
-        params[:linear_constraints]...,
-        NonlinearConstraint.(params[:nonlinear_constraints])...
-    ]
+
+    if isnothing(objective)
+        objective = Objective(params[:objective_terms])
+    end
+
+    if isnothing(constraints)
+        constraints = [
+            params[:linear_constraints]...,
+            NonlinearConstraint.(params[:nonlinear_constraints])...
+        ]
+        build_constraints=false
+    else
+        build_constraints=true
+    end
+
     return UnitaryMinimumTimeProblem(
         trajectory,
         system,
         objective,
         integrators,
         constraints;
-        build_trajectory_constraints=false,
+        build_trajectory_constraints=build_constraints,
         kwargs...
     )
 end
@@ -456,17 +468,28 @@ end
 function UnitaryRobustnessProblem(
     Hₑ::AbstractMatrix{<:Number},
     prob::QuantumControlProblem;
+    constraints::Union{Vector{<:AbstractConstraint}, Nothing}=nothing,
+    objective::Union{Objective, Nothing}=nothing,
     kwargs...
 )
     params = deepcopy(prob.params)
     trajectory = copy(prob.trajectory)
     system = prob.system
-    objective = Objective(params[:objective_terms])
     integrators = prob.integrators
-    constraints = [
-        params[:linear_constraints]...,
-        NonlinearConstraint.(params[:nonlinear_constraints])...
-    ]
+
+    if isnothing(objective)
+        objective = Objective(params[:objective_terms])
+    end
+
+    if isnothing(constraints)
+        constraints = [
+            params[:linear_constraints]...,
+            NonlinearConstraint.(params[:nonlinear_constraints])...
+        ]
+        build_constraints=false
+    else
+        build_constraints=true
+    end
 
     return UnitaryRobustnessProblem(
         Hₑ,
@@ -475,7 +498,7 @@ function UnitaryRobustnessProblem(
         objective,
         integrators,
         constraints;
-        build_trajectory_constraints=false,
+        build_trajectory_constraints=build_constraints,
         kwargs...
     )
 end


### PR DESCRIPTION
Introduces the ability to override quantum control problem defaults in problem templates, for min time and robust problems.

Also adds a default (zero) objective. The zero objective could perhaps be tied to the number 0.0 when adding objectives, as a user convenience, but this was not implemented.

Closes #56 