### PR TITLE
[Feature]: quantum utils docstrings and tests 

### DIFF
--- a/src/quantum_utils.jl
+++ b/src/quantum_utils.jl
@@ -35,17 +35,61 @@ using LinearAlgebra
 using SparseArrays
 
 
-"""
-    kronecker product utility
-"""
+@doc raw"""
+    ⊗(A::AbstractVecOrMat, B::AbstractVecOrMat) = kron(A, B)
 
+The Kronecker product, denoted by `⊗`, results in a block matrix formed by multiplying each element of `A` by the entire matrix `B`.
+
+```julia
+julia> GATES[:X] ⊗ GATES[:Y]
+4×4 Matrix{ComplexF64}:
+ 0.0+0.0im  0.0+0.0im  0.0+0.0im  0.0-1.0im
+ 0.0+0.0im  0.0+0.0im  0.0+1.0im  0.0+0.0im
+ 0.0+0.0im  0.0-1.0im  0.0+0.0im  0.0+0.0im
+ 0.0+1.0im  0.0+0.0im  0.0+0.0im  0.0+0.0im
+```
+"""
 ⊗(A::AbstractVecOrMat, B::AbstractVecOrMat) = kron(A, B)
 
 
-"""
-    quantum gates
-"""
+@doc raw"""
+A constant dictionary `GATES` containing common quantum gate matrices as complex-valued matrices.
 
+- `GATES[:I]` - Identity gate: Leaves the state unchanged.
+- `GATES[:X]` - Pauli-X (NOT) gate: Flips the qubit state.
+- `GATES[:Y]` - Pauli-Y gate: Rotates the qubit state around the Y-axis of the Bloch sphere.
+- `GATES[:Z]` - Pauli-Z gate: Flips the phase of the qubit state.
+- `GATES[:H]` - Hadamard gate: Creates superposition by transforming basis states.
+- `GATES[:CX]` - Controlled-X (CNOT) gate: Flips the second qubit (target) if the first qubit (control) is |1⟩.
+- `GATES[:XI]` - Complex gate: A specific gate used for complex operations.
+- `GATES[:sqrtiSWAP]` - Square root of iSWAP gate: Partially swaps two qubits with a phase.
+
+Each gate is represented by its unitary matrix.
+
+```julia
+julia> GATES[:X]
+2×2 Matrix{ComplexF64}:
+ 0.0+0.0im  1.0+0.0im
+ 1.0+0.0im  0.0+0.0im
+
+julia> GATES[:Y]
+2×2 Matrix{ComplexF64}:
+ 0.0+0.0im  0.0-1.0im
+ 0.0+1.0im  0.0+0.0im
+
+julia> GATES[:Z]
+2×2 Matrix{ComplexF64}:
+ 1.0+0.0im   0.0+0.0im
+ 0.0+0.0im  -1.0+0.0im
+
+julia> get_gate(:CX)
+4×4 Matrix{ComplexF64}:
+ 1.0+0.0im  0.0+0.0im  0.0+0.0im  0.0+0.0im
+ 0.0+0.0im  1.0+0.0im  0.0+0.0im  0.0+0.0im
+ 0.0+0.0im  0.0+0.0im  0.0+0.0im  1.0+0.0im
+ 0.0+0.0im  0.0+0.0im  1.0+0.0im  0.0+0.0im
+```
+"""
 const GATES = Dict{Symbol, Matrix{ComplexF64}}(
     :I => [1 0;
            0 1],
@@ -67,11 +111,6 @@ const GATES = Dict{Symbol, Matrix{ComplexF64}}(
             0 0 0 1;
             0 0 1 0],
 
-    :CZ => [1 0 0 0;
-            0 1 0 0;
-            0 0 1 0;
-            0 0 0 -1],
-
     :XI => [0 0 -im 0;
             0 0 0 -im;
             -im 0 0 0;
@@ -85,6 +124,11 @@ const GATES = Dict{Symbol, Matrix{ComplexF64}}(
 
 get_gate(U::Symbol) = GATES[U]
 
+@doc raw"""
+    apply(gate::Symbol, ψ::Vector{<:Number})
+
+Apply a quantum gate `gate` to a state vector `ψ`.
+"""
 function apply(gate::Symbol, ψ::Vector{<:Number})
     @assert norm(ψ) ≈ 1.0
     @assert gate in keys(GATES) "gate not found"
@@ -93,6 +137,11 @@ function apply(gate::Symbol, ψ::Vector{<:Number})
     return ComplexF64.(normalize(Û * ψ))
 end
 
+@doc raw"""
+    haar_random(n::Int)
+
+Generate a random unitary matrix using the Haar measure for an `n`-dimensional system.
+"""
 function haar_random(n::Int)
     # Ginibre matrix
     Z = (randn(n, n) + im * randn(n, n)) / √2
@@ -102,6 +151,11 @@ function haar_random(n::Int)
     return F.Q * Λ
 end
 
+@doc raw"""
+    haar_identity(n::Int, radius::Number)
+
+Generate a random unitary matrix close to the identity matrix using the Haar measure for an `n`-dimensional system with a given `radius`.
+"""
 function haar_identity(n::Int, radius::Number)
     # Ginibre matrix
     Z = (I + radius * (randn(n, n) + im * randn(n, n)) / √2) / (1 + radius)
@@ -111,7 +165,7 @@ function haar_identity(n::Int, radius::Number)
     return F.Q * Λ
 end
 
-"""
+@doc raw"""
 operators_from_dict(keys::AbstractVector{<:Any}, operator_dictionary; I_key=:I)
 
     Replace the vector of keys using the operators from a dictionary.
@@ -123,7 +177,7 @@ function operators_from_dict(keys::AbstractVector{<:Any}, operator_dictionary; I
     return replace(replace(keys, operator_dictionary...), I_key => I_default)
 end
 
-"""
+@doc raw"""
 operators_from_dict(key_string::String, operator_dictionary; I_key="I")
 
     Replace the string (each character is one key) with operators from a dictionary.
@@ -131,7 +185,7 @@ operators_from_dict(key_string::String, operator_dictionary; I_key="I")
 operators_from_dict(key_string::String, operator_dictionary; I_key="I") =
     operators_from_dict([string(c) for c ∈ key_string], operator_dictionary, I_key=I_key)
 
-"""
+@doc raw"""
 kron_from_dict(keys, dict; kwargs...)
 
     Reduce the keys to a single operator by using the provided dictionary and the kronecker product.
@@ -147,6 +201,11 @@ function kron_from_dict(keys, dict; kwargs...)
     end
 end
 
+@doc raw"""
+    qubit_system_state(ket::String)
+
+Get the state vector for a qubit system given a ket string `ket` of 0s and 1s.
+"""
 function qubit_system_state(ket::String)
     cs = [c for c ∈ ket]
     @assert all(c ∈ "01" for c ∈ cs)
@@ -156,6 +215,11 @@ function qubit_system_state(ket::String)
     return ψ
 end
 
+@doc raw"""
+    lift(U::AbstractMatrix{<:Number}, qubit_index::Int, n_qubits::Int; levels::Int=size(U, 1))
+
+Lift an operator `U` acting on a single qubit to an operator acting on the entire system of `n_qubits`.
+"""
 function lift(
     U::AbstractMatrix{<:Number},
     qubit_index::Int,
@@ -167,6 +231,11 @@ function lift(
     return foldr(⊗, Is)
 end
 
+@doc raw"""
+    lift(op::AbstractMatrix{<:Number}, i::Int, subsystem_levels::Vector{Int})
+
+Lift an operator `op` acting on the i-th subsystem to an operator acting on the entire system with given subsystem levels.
+"""
 function lift(
     op::AbstractMatrix{<:Number},
     i::Int,
@@ -186,7 +255,7 @@ end
     quantum harmonic oscillator operators
 """
 
-"""
+@doc raw"""
     annihilate(levels::Int)
 
 Get the annihilation operator for a system with `levels` levels.
@@ -195,7 +264,7 @@ function annihilate(levels::Int)::Matrix{ComplexF64}
     return diagm(1 => map(sqrt, 1:levels - 1))
 end
 
-"""
+@doc raw"""
     create(levels::Int)
 
 Get the creation operator for a system with `levels` levels.
@@ -204,7 +273,7 @@ function create(levels::Int)
     return collect(annihilate(levels)')
 end
 
-"""
+@doc raw"""
     number(levels::Int)
 
 Get the number operator `n = a'a` for a system with `levels` levels.
@@ -213,7 +282,7 @@ function number(levels::Int)
     return create(levels) * annihilate(levels)
 end
 
-"""
+@doc raw"""
     quad(levels::Int)
 
 Get the operator `n(n - I)` for a system with `levels` levels.
@@ -222,15 +291,43 @@ function quad(levels::Int)
     return number(levels) * (number(levels) - I(levels))
 end
 
+@doc raw"""
+    cavity_state(level::Int, cavity_levels::Int)
 
+Generate the state vector for a given `level` in a cavity system with `cavity_levels` levels.
+
+# Arguments
+- `level::Int`: The index of the desired level (must be between 0 and `cavity_levels` - 1).
+- `cavity_levels::Int`: The total number of levels in the cavity system.
+
+# Returns
+- `Vector{ComplexF64}`: A state vector with `cavity_levels` elements where the element at `level + 1` is 1.0 and all other elements are 0.0.
+
+# Throws
+- `BoundsError`: If `level` is less than 0 or greater than or equal to `cavity_levels`.
+
+# Examples
+```julia
+julia> cavity_state(2, 5)
+5-element Vector{ComplexF64}:
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 1.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+```
+"""
 function cavity_state(level::Int, cavity_levels::Int)
+    if level < 0 || level >= cavity_levels
+        throw(BoundsError("Invalid level index $level for a cavity with $cavity_levels levels."))
+    end
     state = zeros(ComplexF64, cavity_levels)
     state[level + 1] = 1.
     return state
 end
 
 
-"""
+@doc raw"""
     multimode system utilities
 """
 
@@ -260,15 +357,36 @@ end
 """
     isomporphism utilities
 """
+
+@doc raw"""
+    vec⁻¹(x::AbstractVector)
+
+Convert a vector `x` into a square matrix. The length of `x` must be a perfect square.
+"""
 function vec⁻¹(x::AbstractVector)
     n = isqrt(length(x))
     return reshape(x, n, n)
 end
 
+@doc raw"""
+    ket_to_iso(ψ)
+
+Convert a ket vector `ψ` into a complex vector with real and imaginary parts.
+"""
 ket_to_iso(ψ) = [real(ψ); imag(ψ)]
 
+@doc raw"""
+    iso_to_ket(ψ̃)
+
+Convert a complex vector `ψ̃` with real and imaginary parts into a ket vector.
+"""
 iso_to_ket(ψ̃) = ψ̃[1:div(length(ψ̃), 2)] + im * ψ̃[(div(length(ψ̃), 2) + 1):end]
 
+@doc raw"""
+    iso_vec_to_operator(Ũ⃗::AbstractVector{R}) where R <: Real
+
+Convert a real vector `Ũ⃗` into a complex matrix representing an operator.
+"""
 function iso_vec_to_operator(Ũ⃗::AbstractVector{R}) where R <: Real
     Ũ⃗_dim = div(length(Ũ⃗), 2)
     N = Int(sqrt(Ũ⃗_dim))
@@ -281,6 +399,11 @@ function iso_vec_to_operator(Ũ⃗::AbstractVector{R}) where R <: Real
     return U
 end
 
+@doc raw"""
+    iso_vec_to_iso_operator(Ũ⃗::AbstractVector{R}) where R <: Real
+
+Convert a real vector `Ũ⃗` into a real matrix representing an isomorphism operator.
+"""
 function iso_vec_to_iso_operator(Ũ⃗::AbstractVector{R}) where R <: Real
     N = Int(sqrt(length(Ũ⃗) ÷ 2))
     Ũ = Matrix{R}(undef, 2N, 2N)
@@ -297,7 +420,11 @@ function iso_vec_to_iso_operator(Ũ⃗::AbstractVector{R}) where R <: Real
     return Ũ
 end
 
+@doc raw"""
+    operator_to_iso_vec(U::AbstractMatrix{<:Complex})
 
+Convert a complex matrix `U` representing an operator into a real vector.
+"""
 function operator_to_iso_vec(U::AbstractMatrix{<:Complex})
     N = size(U,1)
     Ũ⃗ = Vector{Float64}(undef, N^2 * 2)
@@ -308,6 +435,11 @@ function operator_to_iso_vec(U::AbstractMatrix{<:Complex})
     return Ũ⃗
 end
 
+@doc raw"""
+    iso_operator_to_iso_vec(Ũ::AbstractMatrix{R}) where R <: Real
+
+Convert a real matrix `Ũ` representing an isomorphism operator into a real vector.
+"""
 function iso_operator_to_iso_vec(Ũ::AbstractMatrix{R}) where R <: Real
     N = size(Ũ, 1) ÷ 2
     Ũ⃗ = Vector{R}(undef, N^2 * 2)
@@ -322,18 +454,33 @@ end
     quantum metrics
 """
 
+@doc raw"""
+    fidelity(ψ, ψ_goal; subspace=1:length(ψ))
+
+Calculate the fidelity between two quantum states `ψ` and `ψ_goal`.
+"""
 function fidelity(ψ, ψ_goal; subspace=1:length(ψ))
     ψ = ψ[subspace]
     ψ_goal = ψ_goal[subspace]
     return abs2(ψ_goal' * ψ)
 end
 
+@doc raw"""
+    iso_fidelity(ψ̃, ψ̃_goal; kwargs...)
+
+Calculate the fidelity between two quantum states in their isomorphic form `ψ̃` and `ψ̃_goal`.
+"""
 function iso_fidelity(ψ̃, ψ̃_goal; kwargs...)
     ψ = iso_to_ket(ψ̃)
     ψ_goal = iso_to_ket(ψ̃_goal)
     return fidelity(ψ, ψ_goal; kwargs...)
 end
 
+@doc raw"""
+    unitary_fidelity(U::Matrix, U_goal::Matrix; subspace=nothing)
+
+Calculate the fidelity between two unitary operators `U` and `U_goal`.
+"""
 function unitary_fidelity(
     U::Matrix,
     U_goal::Matrix;
@@ -350,6 +497,11 @@ function unitary_fidelity(
     end
 end
 
+@doc raw"""
+    unitary_fidelity(Ũ⃗::AbstractVector{<:Real}, Ũ⃗_goal::AbstractVector{<:Real}; subspace=nothing)
+
+Calculate the fidelity between two unitary operators in their isomorphic form `Ũ⃗` and `Ũ⃗_goal`.
+"""
 function unitary_fidelity(
     Ũ⃗::AbstractVector{<:Real},
     Ũ⃗_goal::AbstractVector{<:Real};
@@ -366,22 +518,37 @@ end
     quantum measurement functions
 """
 
+@doc raw"""
+    population(ψ̃, i)
+
+Calculate the population of the i-th level for a given state vector `ψ̃` in its isomorphic form.
+"""
 function population(ψ̃, i)
     @assert i ∈ 0:length(ψ̃) ÷ 2 - 1
     ψ = iso_to_ket(ψ̃)
     return abs2(ψ[i + 1])
 end
 
+@doc raw"""
+    populations(ψ::AbstractVector{<:Complex})
+
+Calculate the populations for each level of a given state vector `ψ`.
+"""
 function populations(ψ::AbstractVector{<:Complex})
     return abs2.(ψ)
 end
 
+@doc raw"""
+    populations(ψ̃::AbstractVector{<:Real})
+
+Calculate the populations for each level of a given state vector `ψ̃` in its isomorphic form.
+"""
 function populations(ψ̃::AbstractVector{<:Real})
     return populations(iso_to_ket(ψ̃))
 end
 
 
-"""
+@doc raw"""
     quantum_state(
         ket::String,
         levels::Vector{Int};

--- a/src/quantum_utils.jl
+++ b/src/quantum_utils.jl
@@ -61,6 +61,7 @@ A constant dictionary `GATES` containing common quantum gate matrices as complex
 - `GATES[:Z]` - Pauli-Z gate: Flips the phase of the qubit state.
 - `GATES[:H]` - Hadamard gate: Creates superposition by transforming basis states.
 - `GATES[:CX]` - Controlled-X (CNOT) gate: Flips the second qubit (target) if the first qubit (control) is |1⟩.
+- `GATES[:CZ]` - Controlled-Z (CZ) gate: Flips the phase of the second qubit (target) if the first qubit (control) is |1⟩.
 - `GATES[:XI]` - Complex gate: A specific gate used for complex operations.
 - `GATES[:sqrtiSWAP]` - Square root of iSWAP gate: Partially swaps two qubits with a phase.
 
@@ -110,6 +111,11 @@ const GATES = Dict{Symbol, Matrix{ComplexF64}}(
             0 1 0 0;
             0 0 0 1;
             0 0 1 0],
+
+    :CZ => [1 0 0 0;
+            0 1 0 0;
+            0 0 1 0;
+            0 0 0 -1],
 
     :XI => [0 0 -im 0;
             0 0 0 -im;

--- a/src/quantum_utils.jl
+++ b/src/quantum_utils.jl
@@ -68,16 +68,6 @@ A constant dictionary `GATES` containing common quantum gate matrices as complex
 Each gate is represented by its unitary matrix.
 
 ```julia
-julia> GATES[:X]
-2×2 Matrix{ComplexF64}:
- 0.0+0.0im  1.0+0.0im
- 1.0+0.0im  0.0+0.0im
-
-julia> GATES[:Y]
-2×2 Matrix{ComplexF64}:
- 0.0+0.0im  0.0-1.0im
- 0.0+1.0im  0.0+0.0im
-
 julia> GATES[:Z]
 2×2 Matrix{ComplexF64}:
  1.0+0.0im   0.0+0.0im

--- a/src/quantum_utils.jl
+++ b/src/quantum_utils.jl
@@ -53,7 +53,7 @@ julia> GATES[:X] ⊗ GATES[:Y]
 
 
 @doc raw"""
-A constant dictionary `GATES` containing common quantum gate matrices as complex-valued matrices.
+A constant dictionary `GATES` containing common quantum gate matrices as complex-valued matrices. Each gate is represented by its unitary matrix.
 
 - `GATES[:I]` - Identity gate: Leaves the state unchanged.
 - `GATES[:X]` - Pauli-X (NOT) gate: Flips the qubit state.
@@ -64,8 +64,6 @@ A constant dictionary `GATES` containing common quantum gate matrices as complex
 - `GATES[:CZ]` - Controlled-Z (CZ) gate: Flips the phase of the second qubit (target) if the first qubit (control) is |1⟩.
 - `GATES[:XI]` - Complex gate: A specific gate used for complex operations.
 - `GATES[:sqrtiSWAP]` - Square root of iSWAP gate: Partially swaps two qubits with a phase.
-
-Each gate is represented by its unitary matrix.
 
 ```julia
 julia> GATES[:Z]

--- a/test/quantum_utils_test.jl
+++ b/test/quantum_utils_test.jl
@@ -107,8 +107,6 @@ end
     using LinearAlgebra
     const tol = 1e-10
     levels = 2
-    # For 2 levels, the expected matrix should have a 1 at (1,2) position
-    # since the annihilation operator acts to lower the energy level by one
     expected₂ = [0.0+0.0im  1.0+0.0im; 
 			 0.0+0.0im  0.0+0.0im]
     @test annihilate(levels) == expected₂
@@ -117,14 +115,11 @@ end
                  0.0+0.0im  0.0+0.0im  1.41421+0.0im;
                  0.0+0.0im  0.0+0.0im      0.0+0.0im]
     @test isapprox(expected₃, annihilate(3), atol=1e-2) == true
-  
     @test annihilate(2) == create(2)' 
     @test annihilate(3) == create(3)'
     @test annihilate(4) == create(4)'
-   
     @test number(3) == create(3)* annihilate(3) 
     @test number(4) == create(4)* annihilate(4)
-   
     @test quad(3) == number(3) * (number(3) - I(3))
     @test quad(4) == number(4) * (number(4) - I(4))
 end

--- a/test/quantum_utils_test.jl
+++ b/test/quantum_utils_test.jl
@@ -6,30 +6,23 @@ Tests: QuantumUtils submodule
     using LinearAlgebra
     @test get_gate(:X) * get_gate(:X) ==  get_gate(:I)
     @test get_gate(:Y) * get_gate(:Y) ==  get_gate(:I)
-
-    # Cayley Pauli Table
-    @test im*get_gate(:Y)*get_gate(:X) == get_gate(:Z)  # Z = iYX 
+    @test im*get_gate(:Y)*get_gate(:X) == get_gate(:Z)  # Z = iYX
     @test -im*get_gate(:X)*get_gate(:Y) == get_gate(:Z) # Z = -iXY 
     @test -im*get_gate(:Z)*get_gate(:X) == get_gate(:Y) # Y = -iZX
     @test im*get_gate(:X)*get_gate(:Z) == get_gate(:Y)  # Y = iXZ
     @test im*get_gate(:Z)*get_gate(:Y) == get_gate(:X)  # X = iZY
     @test -im*get_gate(:Y)*get_gate(:Z) == get_gate(:X) # X = -iYZ
 
-    # H*X*H† = Z, H*Z*H† = X, H*Y*H† = -Y
-    @test isapprox(get_gate(:H)*get_gate(:X)*get_gate(:H)', get_gate(:Z), atol=1e-2) == true
-    @test isapprox(get_gate(:H)*get_gate(:Z)*get_gate(:H)', get_gate(:X), atol=1e-2) == true
-    @test isapprox(get_gate(:H)*get_gate(:Y)*get_gate(:H)', -get_gate(:Y), atol=1e-2) == true
+    @test isapprox(get_gate(:H)*get_gate(:X)*get_gate(:H)', get_gate(:Z), atol=1e-2) == true # H*X*H† = Z
+    @test isapprox(get_gate(:H)*get_gate(:Z)*get_gate(:H)', get_gate(:X), atol=1e-2) == true # H*Z*H† = X
+    @test isapprox(get_gate(:H)*get_gate(:Y)*get_gate(:H)', -get_gate(:Y), atol=1e-2) == true # H*Y*H† = -Y
     
-    #H² = I, CNOT² = I, CZ² = I, X² = I, Y² = I, Z² = I
-    @test isapprox(get_gate(:H)*get_gate(:H), get_gate(:I), atol=1e-2) == true
-    @test Int.(round.(real.(GATES[:H]*GATES[:H]))) == GATES[:I]
-    @test GATES[:CX]*GATES[:CX] == I(4)
-    @test GATES[:CZ]*GATES[:CZ] == I(4)
-    @test get_gate(:CX)*get_gate(:CX) == I(4)
-    @test get_gate(:CZ)*get_gate(:CZ) == I(4)
-    @test GATES[:X] ^ 2 == GATES[:I]
-    @test GATES[:Y] ^ 2 == GATES[:I]
-    @test isapprox(GATES[:Z] ^ 2, GATES[:I], atol=1e-2) == true
+    @test isapprox(get_gate(:H)*get_gate(:H), get_gate(:I), atol=1e-2) == true # H² = I
+    @test get_gate(:CX)*get_gate(:CX) == I(4) # CNOT² = I
+    @test get_gate(:CZ)*get_gate(:CZ) == I(4) # CZ² = I
+    @test GATES[:X] ^ 2 == GATES[:I] # X² = I
+    @test GATES[:Y] ^ 2 == GATES[:I] # Y² = I
+    @test isapprox(GATES[:Z] ^ 2, GATES[:I], atol=1e-2) == true # Z² = I
     @test Int.(round.(real.(GATES[:X]*GATES[:Y] + GATES[:Y]*GATES[:X]))) == zeros(2, 2)
     @test Int.(round.(real.(GATES[:Y]*GATES[:Z] + GATES[:Z]*GATES[:Y]))) == zeros(2, 2)
     @test Int.(round.(real.(GATES[:Z]*GATES[:X] + GATES[:X]*GATES[:Z]))) == zeros(2, 2)
@@ -50,9 +43,7 @@ end
     @test apply(:X, ψ₁) == [1.0 + 0.0im, 0.0 + 0.0im]
     @test apply(:Y, ψ₀) == GATES[:Y] * ψ₀  
     @test apply(:Y, ψ₁) == GATES[:Y] * ψ₁
-   
-    # H * H = I 
-    @test apply(:H, apply(:H, [1,  0])) == [1, 0]
+    @test apply(:H, apply(:H, [1,  0])) == [1, 0]  # H * H = I 
     @test isapprox(apply(:H, apply(:H, apply(:H, [1,  0]))), [0.7071, 0.7071], atol=1e-1) == true
     @test apply(:CX, [1, 0, 0, 0]) == [1, 0, 0, 0]  # CNOT |00⟩ = |00⟩
     @test apply(:CX, [0, 1, 0, 0]) == [0, 1, 0, 0]  # CNOT |01⟩ = |01⟩

--- a/test/quantum_utils_test.jl
+++ b/test/quantum_utils_test.jl
@@ -2,6 +2,123 @@
 Tests: QuantumUtils submodule
 """
 
-@testitem "QuantumUtils test" begin
-    # TODO: Implement tests
+@testitem "GATES" begin
+    using LinearAlgebra
+    @test get_gate(:X) * get_gate(:X) ==  get_gate(:I)
+    @test get_gate(:Y) * get_gate(:Y) ==  get_gate(:I)
+
+    # Cayley Pauli Table
+    @test im*get_gate(:Y)*get_gate(:X) == get_gate(:Z)  # Z = iYX 
+    @test -im*get_gate(:X)*get_gate(:Y) == get_gate(:Z) # Z = -iXY 
+    @test -im*get_gate(:Z)*get_gate(:X) == get_gate(:Y) # Y = -iZX
+    @test im*get_gate(:X)*get_gate(:Z) == get_gate(:Y)  # Y = iXZ
+    @test im*get_gate(:Z)*get_gate(:Y) == get_gate(:X)  # X = iZY
+    @test -im*get_gate(:Y)*get_gate(:Z) == get_gate(:X) # X = -iYZ
+
+    # H*X*H† = Z, H*Z*H† = X, H*Y*H† = -Y
+    @test isapprox(GATES[:H]*GATES[:X]*GATES[:H]', GATES[:Z], atol=1e-2) == true
+    @test isapprox(get_gate(:H)*get_gate(:X)*get_gate(:H)', get_gate(:Z), atol=1e-2) == true
+    @test isapprox(GATES[:H]*GATES[:Z]*GATES[:H]', GATES[:X], atol=1e-2) == true
+    @test isapprox(get_gate(:H)*get_gate(:Z)*get_gate(:H)', get_gate(:X), atol=1e-2) == true
+    @test isapprox(GATES[:H]*GATES[:Y]*GATES[:H]', -GATES[:Y], atol=1e-2) == true
+    @test isapprox(get_gate(:H)*get_gate(:Y)*get_gate(:H)', -get_gate(:Y), atol=1e-2) == true
+    
+    #H*H = I, CNOT*CNOT = I, X² = I, Y² = I, Z² = I
+    @test isapprox(GATES[:H]*GATES[:H], GATES[:I], atol=1e-2) == true
+    @test isapprox(get_gate(:H)*get_gate(:H), get_gate(:I), atol=1e-2) == true
+    @test Int.(round.(real.(GATES[:H]*GATES[:H]))) == GATES[:I]
+    @test GATES[:CX]*GATES[:CX] == I(4)
+    @test get_gate(:CX)*get_gate(:CX) == I(4)
+    @test GATES[:X] ^ 2 == GATES[:I]
+    @test isapprox(GATES[:X] ^ 2, GATES[:I], atol=1e-2) == true
+    @test GATES[:Y] ^ 2 == GATES[:I]
+    @test isapprox(GATES[:Y] ^ 2, GATES[:I], atol=1e-2) == true
+    @test isapprox(GATES[:Z] ^ 2, GATES[:I], atol=1e-2) == true
+
+    @test Int.(round.(real.(GATES[:X]*GATES[:Y] + GATES[:Y]*GATES[:X]))) == zeros(2, 2)
+    @test Int.(round.(real.(GATES[:Y]*GATES[:Z] + GATES[:Z]*GATES[:Y]))) == zeros(2, 2)
+    @test Int.(round.(real.(GATES[:Z]*GATES[:X] + GATES[:X]*GATES[:Z]))) == zeros(2, 2)
+end
+
+@testitem "⊗" begin
+    using LinearAlgebra
+    @test Int.(real.(GATES[:I] ⊗ GATES[:I])) == I(4)
+    #Associativity
+    @test (GATES[:X] ⊗ GATES[:Y]) ⊗ GATES[:Z] == GATES[:X] ⊗ (GATES[:Y] ⊗ GATES[:Z])
+    #Distributivity    
+    @test GATES[:X] ⊗ (GATES[:Y] + GATES[:Z]) == GATES[:X] ⊗ GATES[:Y] + GATES[:X] ⊗ GATES[:Z]
+end 
+
+@testitem "Test apply function with Pauli gates" begin
+    using LinearAlgebra
+    ψ₀ = [1.0 + 0.0im, 0.0 + 0.0im] 
+    ψ₁ = [0.0 + 0.0im, 1.0 + 0.0im]
+    @test apply(:X, ψ₀) == [0.0 + 0.0im, 1.0 + 0.0im] 
+    @test apply(:X, ψ₁) == [1.0 + 0.0im, 0.0 + 0.0im]
+    @test apply(:Y, ψ₀) == GATES[:Y] * ψ₀  
+    @test apply(:Y, ψ₁) == GATES[:Y] * ψ₁
+   
+    # H * H = I 
+    @test apply(:H, apply(:H, [1,  0])) == [1, 0]
+    @test isapprox(apply(:H, apply(:H, apply(:H, [1,  0]))), [0.7071, 0.7071], atol=1e-1) == true
+    @test apply(:CX, [1, 0, 0, 0]) == [1, 0, 0, 0]  # CNOT |00⟩ = |00⟩
+    @test apply(:CX, [0, 1, 0, 0]) == [0, 1, 0, 0]  # CNOT |10⟩ = |10⟩
+    @test apply(:CX, [0, 0, 1, 0]) == [0, 0, 0, 1]  # CNOT |01⟩ = |11⟩
+    @test apply(:CX, [0, 0, 0, 1]) == [0, 0, 1, 0]  # CNOT |11⟩ = |10⟩
+end
+
+@testitem "Test qubit_system_state function" begin
+    using LinearAlgebra
+    @test qubit_system_state("0") == [1, 0]
+    @test qubit_system_state("1") == [0, 1]
+    @test qubit_system_state("00") == [1, 0, 0, 0]
+    @test qubit_system_state("01") == [0, 1, 0, 0]
+    @test qubit_system_state("10") == [0, 0, 1, 0]
+    @test qubit_system_state("11") == [0, 0, 0, 1]
+end
+
+@testitem "Test lift function" begin
+    using LinearAlgebra
+    U1 = [1 0; 0 1] 
+    @test size(lift(U1, 1, 2)) == (4, 4)
+    @test size(lift(U1, 2, 2)) == (4, 4)
+    @test size(lift(U1, 1, 3)) == (8, 8)
+end
+
+@testitem "Test isomorphism utilities" begin
+    using LinearAlgebra
+    iso_vec = [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+    @test vec⁻¹([1.0, 2.0, 3.0, 4.0]) == [1.0 3.0; 2.0 4.0]
+    @test ket_to_iso([1.0, 2.0]) == [1.0, 2.0, 0.0, 0.0]
+    @test iso_to_ket([1.0, 2.0, 0.0, 0.0]) == [1.0, 2.0]
+    @test iso_vec_to_operator(iso_vec) == [1.0 0.0; 0.0 1.0]
+    @test iso_vec_to_iso_operator(iso_vec) == [1.0 0.0 -0.0 -0.0; 0.0 1.0 -0.0 -0.0; 0.0 0.0 1.0 0.0; 0.0 0.0 0.0 1.0]
+    @test operator_to_iso_vec(Complex[1.0 0.0; 0.0 1.0]) == iso_vec
+    @test iso_operator_to_iso_vec(iso_vec_to_iso_operator(iso_vec)) == iso_vec
+end
+
+@testitem "quantum harmonic oscillator operators" begin
+    using LinearAlgebra
+    const tol = 1e-10
+    levels = 2
+    # For 2 levels, the expected matrix should have a 1 at (1,2) position
+    # since the annihilation operator acts to lower the energy level by one
+    expected₂ = [0.0+0.0im  1.0+0.0im; 
+			 0.0+0.0im  0.0+0.0im]
+    @test annihilate(levels) == expected₂
+    levels = 3
+    expected₃ = [0.0+0.0im  1.0+0.0im      0.0+0.0im;
+                 0.0+0.0im  0.0+0.0im  1.41421+0.0im;
+                 0.0+0.0im  0.0+0.0im      0.0+0.0im]
+    @test isapprox(expected₃, annihilate(3), atol=1e-2) == true
+  
+    @test annihilate(2) == create(2)' 
+    @test annihilate(3) == create(3)'
+    @test annihilate(4) == create(4)'
+   
+    @test number(3) == create(3)* annihilate(3) 
+    @test number(4) == create(4)* annihilate(4)
+   
+    @test quad(3) == number(3) * (number(3) - I(3))
+    @test quad(4) == number(4) * (number(4) - I(4))
 end

--- a/test/quantum_utils_test.jl
+++ b/test/quantum_utils_test.jl
@@ -16,15 +16,11 @@ Tests: QuantumUtils submodule
     @test -im*get_gate(:Y)*get_gate(:Z) == get_gate(:X) # X = -iYZ
 
     # H*X*H† = Z, H*Z*H† = X, H*Y*H† = -Y
-    @test isapprox(GATES[:H]*GATES[:X]*GATES[:H]', GATES[:Z], atol=1e-2) == true
     @test isapprox(get_gate(:H)*get_gate(:X)*get_gate(:H)', get_gate(:Z), atol=1e-2) == true
-    @test isapprox(GATES[:H]*GATES[:Z]*GATES[:H]', GATES[:X], atol=1e-2) == true
     @test isapprox(get_gate(:H)*get_gate(:Z)*get_gate(:H)', get_gate(:X), atol=1e-2) == true
-    @test isapprox(GATES[:H]*GATES[:Y]*GATES[:H]', -GATES[:Y], atol=1e-2) == true
     @test isapprox(get_gate(:H)*get_gate(:Y)*get_gate(:H)', -get_gate(:Y), atol=1e-2) == true
     
     #H² = I, CNOT² = I, CZ² = I, X² = I, Y² = I, Z² = I
-    @test isapprox(GATES[:H]*GATES[:H], GATES[:I], atol=1e-2) == true
     @test isapprox(get_gate(:H)*get_gate(:H), get_gate(:I), atol=1e-2) == true
     @test Int.(round.(real.(GATES[:H]*GATES[:H]))) == GATES[:I]
     @test GATES[:CX]*GATES[:CX] == I(4)
@@ -32,9 +28,7 @@ Tests: QuantumUtils submodule
     @test get_gate(:CX)*get_gate(:CX) == I(4)
     @test get_gate(:CZ)*get_gate(:CZ) == I(4)
     @test GATES[:X] ^ 2 == GATES[:I]
-    @test isapprox(GATES[:X] ^ 2, GATES[:I], atol=1e-2) == true
     @test GATES[:Y] ^ 2 == GATES[:I]
-    @test isapprox(GATES[:Y] ^ 2, GATES[:I], atol=1e-2) == true
     @test isapprox(GATES[:Z] ^ 2, GATES[:I], atol=1e-2) == true
     @test Int.(round.(real.(GATES[:X]*GATES[:Y] + GATES[:Y]*GATES[:X]))) == zeros(2, 2)
     @test Int.(round.(real.(GATES[:Y]*GATES[:Z] + GATES[:Z]*GATES[:Y]))) == zeros(2, 2)

--- a/test/quantum_utils_test.jl
+++ b/test/quantum_utils_test.jl
@@ -23,12 +23,14 @@ Tests: QuantumUtils submodule
     @test isapprox(GATES[:H]*GATES[:Y]*GATES[:H]', -GATES[:Y], atol=1e-2) == true
     @test isapprox(get_gate(:H)*get_gate(:Y)*get_gate(:H)', -get_gate(:Y), atol=1e-2) == true
     
-    #H*H = I, CNOT*CNOT = I, X² = I, Y² = I, Z² = I
+    #H² = I, CNOT² = I, CZ² = I, X² = I, Y² = I, Z² = I
     @test isapprox(GATES[:H]*GATES[:H], GATES[:I], atol=1e-2) == true
     @test isapprox(get_gate(:H)*get_gate(:H), get_gate(:I), atol=1e-2) == true
     @test Int.(round.(real.(GATES[:H]*GATES[:H]))) == GATES[:I]
     @test GATES[:CX]*GATES[:CX] == I(4)
+    @test GATES[:CZ]*GATES[:CZ] == I(4)
     @test get_gate(:CX)*get_gate(:CX) == I(4)
+    @test get_gate(:CZ)*get_gate(:CZ) == I(4)
     @test GATES[:X] ^ 2 == GATES[:I]
     @test isapprox(GATES[:X] ^ 2, GATES[:I], atol=1e-2) == true
     @test GATES[:Y] ^ 2 == GATES[:I]
@@ -62,9 +64,13 @@ end
     @test apply(:H, apply(:H, [1,  0])) == [1, 0]
     @test isapprox(apply(:H, apply(:H, apply(:H, [1,  0]))), [0.7071, 0.7071], atol=1e-1) == true
     @test apply(:CX, [1, 0, 0, 0]) == [1, 0, 0, 0]  # CNOT |00⟩ = |00⟩
-    @test apply(:CX, [0, 1, 0, 0]) == [0, 1, 0, 0]  # CNOT |10⟩ = |10⟩
-    @test apply(:CX, [0, 0, 1, 0]) == [0, 0, 0, 1]  # CNOT |01⟩ = |11⟩
+    @test apply(:CX, [0, 1, 0, 0]) == [0, 1, 0, 0]  # CNOT |01⟩ = |01⟩
+    @test apply(:CX, [0, 0, 1, 0]) == [0, 0, 0, 1]  # CNOT |10⟩ = |11⟩
     @test apply(:CX, [0, 0, 0, 1]) == [0, 0, 1, 0]  # CNOT |11⟩ = |10⟩
+    @test apply(:CZ, [1, 0, 0, 0]) == [1, 0, 0, 0]  # CZ |00⟩ = |00⟩
+    @test apply(:CZ, [0, 1, 0, 0]) == [0, 1, 0, 0]  # CZ |01⟩ = |01⟩
+    @test apply(:CZ, [0, 0, 1, 0]) == [0, 0, 1, 0]  # CZ |10⟩ = |10⟩
+    @test apply(:CZ, [0, 0, 0, 1]) == [0, 0, 0, -1] # CZ |11⟩ = -|11⟩
 end
 
 @testitem "Test qubit_system_state function" begin

--- a/test/quantum_utils_test.jl
+++ b/test/quantum_utils_test.jl
@@ -36,7 +36,6 @@ Tests: QuantumUtils submodule
     @test GATES[:Y] ^ 2 == GATES[:I]
     @test isapprox(GATES[:Y] ^ 2, GATES[:I], atol=1e-2) == true
     @test isapprox(GATES[:Z] ^ 2, GATES[:I], atol=1e-2) == true
-
     @test Int.(round.(real.(GATES[:X]*GATES[:Y] + GATES[:Y]*GATES[:X]))) == zeros(2, 2)
     @test Int.(round.(real.(GATES[:Y]*GATES[:Z] + GATES[:Z]*GATES[:Y]))) == zeros(2, 2)
     @test Int.(round.(real.(GATES[:Z]*GATES[:X] + GATES[:X]*GATES[:Z]))) == zeros(2, 2)
@@ -45,10 +44,8 @@ end
 @testitem "⊗" begin
     using LinearAlgebra
     @test Int.(real.(GATES[:I] ⊗ GATES[:I])) == I(4)
-    #Associativity
-    @test (GATES[:X] ⊗ GATES[:Y]) ⊗ GATES[:Z] == GATES[:X] ⊗ (GATES[:Y] ⊗ GATES[:Z])
-    #Distributivity    
-    @test GATES[:X] ⊗ (GATES[:Y] + GATES[:Z]) == GATES[:X] ⊗ GATES[:Y] + GATES[:X] ⊗ GATES[:Z]
+    @test (GATES[:X] ⊗ GATES[:Y]) ⊗ GATES[:Z] == GATES[:X] ⊗ (GATES[:Y] ⊗ GATES[:Z]) # Associativity
+    @test GATES[:X] ⊗ (GATES[:Y] + GATES[:Z]) == GATES[:X] ⊗ GATES[:Y] + GATES[:X] ⊗ GATES[:Z] # Distributivity   
 end 
 
 @testitem "Test apply function with Pauli gates" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ include("test_utils.jl")
     # include("objectives_test.jl")
     # include("dynamics_test.jl")
     include("integrators_test.jl")
+    include("quantum_utils_test.jl")
 end
 
 @run_package_tests


### PR DESCRIPTION
This PR aims to Resolve Issue https://github.com/aarontrowbridge/QuantumCollocation.jl/issues/102 and is an improvement over the PR #111 

Sorry, my earlier  PR #111  was rough. I have made sure this one is nice and clear! This will save your time during the review, @aarontrowbridge and @andgoldschmidt!

I have also newely added test for the newly added `CZ `gates as well!
```
    @test apply(:CZ, [1, 0, 0, 0]) == [1, 0, 0, 0]  # CZ |00⟩ = |00⟩
    @test apply(:CZ, [0, 1, 0, 0]) == [0, 1, 0, 0]  # CZ |01⟩ = |01⟩
    @test apply(:CZ, [0, 0, 1, 0]) == [0, 0, 1, 0]  # CZ |10⟩ = |10⟩
    @test apply(:CZ, [0, 0, 0, 1]) == [0, 0, 0, -1] # CZ |11⟩ = -|11⟩
```
Implementation details are as follows:

1. Write `docstrings` for all of the functions in `src/quantum_utils.jl`
2. Add` tests` for the functions in `test/quantum_utils_test.jl`

This PR implements tests for QuantumUtils along with providing docstrings in the` src/quantum_utils.`

TestItems creates for the following:
1. GATES
2. ⊗
3. apply
4. qubit_system_state function
5. lift function
6. isomorphism utilities
7. quantum harmonic oscillator operators


Docstrings include the argument signatures, and a short description. The copiolot stuff is not touched upon in this PR. 
Only a few relevant commits with complete description are done so make a clear and concise PR. 

Testing: Complete testing of the TestItems have done locally. Instead of 19 commits, only few commits is done and files are shortened and redundant comments have been removed.

```
Test Summary:                                           | Pass  Fail  Total     Time
Package                                                 |  218     2    220  3m20.4s
  test/direct_sums_test.jl                              |   44           44    55.6s
  test/quantum_utils_test.jl                            |   71           71     9.6s
  test/rollouts_test.jl                                 |   18           18     7.2s
  test/problems_test.jl                                 |    1            1     4.5s
  src/problem_templates/unitary_minimum_time_problem.jl |    3            3    49.3s
  test/quantum_system_utils_test.jl                     |   15           15     4.8s
  src/problem_templates/unitary_robustness_problem.jl   |    3     2      5    57.4s
    Robust and Subspace Templates                       |    3     2      5    57.4s
  src/problem_templates/unitary_smooth_pulse_problem.jl |    1            1     5.3s
  test/losses_test.jl                                   |   21           21     0.7s
  test/embedded_operators_test.jl                       |   28           28     1.2s
  src/problem_templates/unitary_direct_sum_problem.jl   |   13           13     4.8s

```